### PR TITLE
Add IP handling to ceph monitor lookup.

### DIFF
--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -210,6 +210,10 @@ func findDNSIP(p *rbdProvisioner) (dnsip string) {
 
 // Look up hostname in dns server serverip.
 func lookuphost(hostname string, serverip string) (iplist []string, err error) {
+	if net.ParseIP(hostname) != nil {
+		glog.V(4).Infof("detected IP address %q\n", hostname)
+		return append(iplist, hostname), nil
+	}
 	glog.V(4).Infof("lookuphost %q on %q\n", hostname, serverip)
 	m := new(dns.Msg)
 	m.SetQuestion(dns.Fqdn(hostname), dns.TypeA)


### PR DESCRIPTION
Return IP address and avoid hostname lookup when ceph monitors are given as IP addresses.
Closes #772